### PR TITLE
Support pagination for vault#blobs

### DIFF
--- a/lib/truevault/vault.rb
+++ b/lib/truevault/vault.rb
@@ -16,8 +16,10 @@ module TrueVault
     # list all blobs in vault
     # TVVault.blobs("00000000-0000-0000-0000-000000000000")
 
-    def blobs(vault_id)
-      self.class.get("/#{@api_ver}/vaults/#{vault_id}/blobs", default_options_to_merge_with)
+    def blobs(vault_id, page: 1, per_page: 100)
+      options = { query: { page: page, per_page: per_page } }
+      options.merge!(default_options_to_merge_with)
+      self.class.get("/#{@api_ver}/vaults/#{vault_id}/blobs", options)
     end
 
     # creates a vault

--- a/lib/truevault/version.rb
+++ b/lib/truevault/version.rb
@@ -1,3 +1,3 @@
 module TrueVault
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
- TrueVault blob list defaults to 100 records
- Optional `page` and `per_page` arguments are passed through to TrueVault API
- These parameters are undocumented, but they do work!

Sample usage with truncated TrueVault responses:

```
> vault.blobs(vault_id)
{"data"=>{"items"=>[...], "page"=>1, "per_page"=>100, "total"=>51}, "result"=>"success"}

> vault.blobs(vault_id, page: 2)
{"data"=>{"items"=>[], "page"=>2, "per_page"=>100, "total"=>51}, "result"=>"success"}

> vault.blobs(vault_id, per_page: 500)
{"data"=>{"items"=>[...], "page"=>1, "per_page"=>500, "total"=>51}, "result"=>"success"}

> vault.blobs(vault_id, page: 3, per_page: 500)
{"data"=>{"items"=>[], "page"=>3, "per_page"=>500, "total"=>51}, "result"=>"success"}
```
