### PR TITLE
Wrapper for Groups API + tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,46 @@
 PATH
   remote: .
   specs:
-    truevault (0.0.1)
+    truevault (0.1.0)
       httparty (~> 0.11)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.0.13)
+      i18n (~> 0.6, >= 0.6.9)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
     addressable (2.3.5)
     ansi (1.4.3)
+    coderay (1.1.1)
     crack (0.4.1)
       safe_yaml (~> 0.9.0)
     dotenv (1.0.2)
-    httparty (0.13.1)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    json (1.8.1)
+    i18n (0.7.0)
+    json (1.8.3)
+    method_source (0.8.2)
+    minitest (4.7.5)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.1.0)
     safe_yaml (0.9.7)
+    slop (3.6.0)
+    thread_safe (0.3.5)
     turn (0.9.6)
       ansi
+    tzinfo (0.3.51)
     vcr (2.5.0)
     webmock (1.11.0)
       addressable (>= 2.2.7)
@@ -32,8 +52,14 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.6)
   dotenv
+  factory_girl (~> 4.0)
+  minitest (~> 4.7)
+  pry
   rake (~> 10.1)
   truevault!
   turn (~> 0.9)
   vcr (~> 2.5)
   webmock (= 1.11)
+
+BUNDLED WITH
+   1.11.2

--- a/lib/truevault.rb
+++ b/lib/truevault.rb
@@ -1,12 +1,13 @@
-require 'rubygems'
-require 'bundler/setup'
-require 'tempfile'
-require 'httparty'
-require 'truevault/user'
-require 'truevault/document'
-require 'truevault/blob'
-require 'truevault/vault'
-require 'truevault/schema'
-require 'truevault/authorization'
+require "rubygems"
+require "bundler/setup"
+require "tempfile"
+require "httparty"
+require "truevault/user"
+require "truevault/document"
+require "truevault/blob"
+require "truevault/group"
+require "truevault/vault"
+require "truevault/schema"
+require "truevault/authorization"
 
 Bundler.require

--- a/lib/truevault/client.rb
+++ b/lib/truevault/client.rb
@@ -45,6 +45,14 @@ module TrueVault
       Base64.encode64(hash.to_json)
     end
 
+    def to_string(value = [])
+      if value.is_a?(Array)
+        value.join(",")
+      elsif value.is_a?(String)
+        value
+      end
+    end
+
     # api_key         should be a valid TrueVault API key
     # account_id      should be a valid TrueVault account ID
     # api_version     should be a valid API version (ex 'v1')

--- a/lib/truevault/group.rb
+++ b/lib/truevault/group.rb
@@ -1,0 +1,72 @@
+require "truevault/client"
+
+module TrueVault
+  class Group < Client
+    def create(options = {})
+      query = {
+        query: {
+          name: options[:name],
+          policy: policy(options),
+          user_ids: to_string(options[:user_ids])
+          }
+        }
+      new_options = default_options_to_merge_with.merge(query)
+      self.class.post("/#{@api_ver}/groups", new_options)
+    end
+
+    def find(group_id, options = {})
+      options.merge!(default_options_to_merge_with)
+      self.class.get("/#{@api_ver}/groups/#{group_id}", options)
+    end
+
+    def delete(group_id, options = {})
+      options.merge!(default_options_to_merge_with)
+      self.class.delete("/#{@api_ver}/groups/#{group_id}", options)
+    end
+
+    def update(group_id, options = {})
+      query = {}
+      query[:name] = options[:name] if options[:name]
+      query[:policy] = policy(options) if options[:policy]
+      query[:user_ids] = to_string(options[:user_ids]) if options[:user_ids]
+      query[:operation] = options[:operation] if options[:operation]
+
+      new_options = default_options_to_merge_with.merge(query: query)
+      self.class.put("/#{@api_ver}/groups/#{group_id}", new_options)
+    end
+
+    def add_users(group_id, user_ids)
+      query = {
+        query: {
+          user_ids: to_string(user_ids),
+          operation: "APPEND"
+          }
+        }
+      new_options = default_options_to_merge_with.merge(query)
+      self.class.put("/#{@api_ver}/groups/#{group_id}", new_options)
+    end
+
+    def remove_users(group_id, user_ids)
+      query = {
+        query: {
+          user_ids: to_string(user_ids),
+          operation: "REMOVE"
+          }
+        }
+      new_options = default_options_to_merge_with.merge(query)
+      self.class.put("/#{@api_ver}/groups/#{group_id}", new_options)
+    end
+
+    def all
+      self.class.get("/#{@api_ver}/groups", default_options_to_merge_with)
+    end
+
+    private
+
+    def policy(options)
+      if options[:policy]
+        hash_to_base64_json(options[:policy])
+      end
+    end
+  end
+end

--- a/lib/truevault/version.rb
+++ b/lib/truevault/version.rb
@@ -1,3 +1,3 @@
 module TrueVault
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :deletable_group, class: OpenStruct do
+    name "deletable_group_#{SecureRandom.hex}"
+  end
+
+  factory :group, class: OpenStruct do
+    name "test_group_#{SecureRandom.hex}"
+  end
+
+  factory :user, class: OpenStruct do
+    username "test_user_#{SecureRandom.hex}"
+    password "password"
+  end
+
+  factory :user_attributes, class: OpenStruct do
+    name "John"
+    type "patient"
+  end
+end

--- a/spec/fixtures/truevault_cassettes/add_user_to_group.yml
+++ b/spec/fixtures/truevault_cassettes/add_user_to_group.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups/REDACTED_ID?operation=APPEND&user_ids=REDACTED_ID
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 21 Jul 2016 00:36:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"group": {"group_id": "8ae6ed30-0662-4ec7-9bce-8ee71c0e468c", "id":
+        "REDACTED_ID", "name": "test group", "policy": [], "user_ids": ["REDACTED_ID"]},
+        "result": "success", "transaction_id": "REDACTED_ID"}'
+    http_version: 
+  recorded_at: Thu, 21 Jul 2016 00:36:51 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/create_deletable_group.yml
+++ b/spec/fixtures/truevault_cassettes/create_deletable_group.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups?name=deletable_group_0f0203abf27eca728ba9429e3b6368d9&policy=&user_ids=
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 21 Jul 2016 01:02:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '278'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"group": {"group_id": "bee4fd06-b54c-4349-a76f-cd39a20da64f", "id":
+        "REDACTED_ID", "name": "deletable_group_0f0203abf27eca728ba9429e3b6368d9",
+        "policy": [], "user_ids": []}, "result": "success", "transaction_id": "REDACTED_ID"}'
+    http_version: 
+  recorded_at: Thu, 21 Jul 2016 01:02:45 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/create_group.yml
+++ b/spec/fixtures/truevault_cassettes/create_group.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups?name=test%20group&policy=&user_ids=
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 21 Jul 2016 00:32:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '240'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"group": {"group_id": "8ae6ed30-0662-4ec7-9bce-8ee71c0e468c", "id":
+        "REDACTED_ID", "name": "test group", "policy": [], "user_ids": []}, "result":
+        "success", "transaction_id": "REDACTED_ID"}'
+    http_version: 
+  recorded_at: Thu, 21 Jul 2016 00:32:20 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/create_user.yml
+++ b/spec/fixtures/truevault_cassettes/create_user.yml
@@ -2,26 +2,32 @@
 http_interactions:
 - request:
     method: post
-    uri: https://REDACTED_ID:@api.truevault.com/v1/users?attributes=eyJpZCI6IjAwMCIsIm5hbWUiOiJKb2huIiwidHlwZSI6InBhdGllbnQifQ==%0A&password=password&username=test_user_3
+    uri: https://REDACTED_ID:@api.truevault.com/v1/users?attributes=eyJpZCI6MCwibmFtZSI6IkpvaG4iLCJ0eXBlIjoicGF0aWVudCJ9%0A&password=password&username=test_user_16936d2aa3128d13d31517301f3bc73f
     body:
       encoding: UTF-8
       string: ''
-    headers: {}
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 08 Jan 2015 17:08:25 GMT
+      - Thu, 21 Jul 2016 00:36:49 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '571'
+      - '635'
       Connection:
       - keep-alive
       Server:
-      - gunicorn/18.0
+      - gunicorn/19.3.0
       Cache-Control:
       - no-cache
       Strict-Transport-Security:
@@ -29,9 +35,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"result": "success", "transaction_id": "REDACTED_ID", "user": {"access_key":
-        null, "access_token": ".eJwly0kOwjAMQNG7ZAuWbJMmTpYcoWJfZTCoYlSHRYW4OxFsv95_m2W867yk-8tEw0gdIAHKiXxEiWx3iBHR7H9uuOrW2MT9dulv2R1bX2edhrG2bD2ns-8EsqsKtpJCqD6AL8VmrexDOrQhlfJcH8v_qY4pMDqQzAWsswoJSwKhKkQhaxExny80JS5d.B5BLCA.mGsCgfNYnGiLsBdtNaw0afVGd8U",
-        "account_id": "REDACTED_ID", "api_key": null, "id": "REDACTED_ID", "status":
-        "ACTIVATED", "user_id": "REDACTED_ID", "username": "test_user_3"}}'
+        null, "access_token": ".eJwli8sKwjAQAP8lV13YzXv7Ex6059JuGghSKzZFRPx3g96GYeatalnmrY7LXXVKI3nAAJouiJ3xneVDA0R1_HXDdX61rJx791xPfabm921-DCU1LZ5DQrSQ4pjBTlkgekegxbDoqNOkuQ2jyLrf6v-Jhh2iGEiJHFhnGFiCA8PEyJGiDaI-XwmqLOM.CnGqoQ.mE7JNx5b-JQQ64WGbBH_elwD2wE",
+        "account_id": "REDACTED_ID", "api_key": "REDACTED_ID", "id": "REDACTED_ID",
+        "status": "ACTIVATED", "user_id": "c697d004-d8af-4bfc-8651-2c39c282db29",
+        "username": "test_user_16936d2aa3128d13d31517301f3bc73f"}}'
     http_version: 
-  recorded_at: Thu, 08 Jan 2015 17:08:25 GMT
+  recorded_at: Thu, 21 Jul 2016 00:36:49 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/delete_group.yml
+++ b/spec/fixtures/truevault_cassettes/delete_group.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups/REDACTED_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 21 Jul 2016 00:37:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '224'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"group": {"group_id": "8ae6ed30-0662-4ec7-9bce-8ee71c0e468c", "id":
+        "REDACTED_ID", "name": "test group", "policy": []}, "result": "success", "transaction_id":
+        "REDACTED_ID"}'
+    http_version: 
+  recorded_at: Thu, 21 Jul 2016 00:37:18 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/find_group.yml
+++ b/spec/fixtures/truevault_cassettes/find_group.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups/REDACTED_ID
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Jul 2016 22:28:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '220'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"group": {"group_id": "3d88a00b-a87a-417c-ad12-bd01c4a9693a", "id":
+        "REDACTED_ID", "name": "sample", "policy": []}, "result": "success", "transaction_id":
+        "REDACTED_ID"}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 22:28:04 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/list_groups.yml
+++ b/spec/fixtures/truevault_cassettes/list_groups.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Jul 2016 22:59:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1789'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"groups": [{"group_id": "d531a96c-ae06-4d08-9b6d-7e701bf7dc8a", "id":
+        "REDACTED_ID", "name": "FULL_ADMIN", "policy": [{"Activities": "CRUDA", "Resources":
+        ["Vault::.*"]}, {"Activities": "CRUDA", "Resources": ["Vault::.*::Schema::.*",
+        "Vault::.*::Document::.*", "Vault::.*::Blob::.*"]}, {"Activities": "CRUDA",
+        "Resources": ["Vault::.*::Search::.*"]}, {"Activities": "CRUDA", "Resources":
+        ["Account::.*", "User::.*", "Group::.*", "UserVault::.*"]}, {"Activities":
+        "CRUDA", "Resources": ["Client::.*"]}, {"Activities": "CRUDA", "Resources":
+        ["Scope::.*"]}]}, {"group_id": "1a4fd76f-b624-42c8-9516-3d058c262037",
+        "id": "REDACTED_ID", "name": "READ_ONLY", "policy": [{"Activities": "R", "Resources":
+        ["Vault::.*", "Vault::.*::Document::.*", "Vault::.*::Blob::.*"]}]}, {"group_id":
+        "65657c60-3ec6-4489-9c31-dd85254d4242", "id": "REDACTED_ID", "name": "sample-group",
+        "policy": []}, {"group_id": "85c34e4f-aa3e-4080-a4c9-149523c3ee69", "id":
+        "REDACTED_ID", "name": "WRITE_ONLY", "policy": [{"Activities": "C", "Resources":
+        ["Vault::.*::Document::.*", "Vault::.*::Blob::.*"]}]}], "result": "success",
+        "transaction_id": "REDACTED_ID"}'
+    http_version:
+  recorded_at: Wed, 20 Jul 2016 22:59:27 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/remove_user_from_group.yml
+++ b/spec/fixtures/truevault_cassettes/remove_user_from_group.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups/REDACTED_ID?operation=REMOVE&user_ids=REDACTED_ID
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Jul 2016 22:43:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '236'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"group": {"group_id": "3d88a00b-a87a-417c-ad12-bd01c4a9693a", "id":
+        "REDACTED_ID", "name": "sample", "policy": [], "user_ids": []}, "result":
+        "success", "transaction_id": "REDACTED_ID"}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 22:43:59 GMT
+recorded_with: VCR 2.5.0

--- a/spec/fixtures/truevault_cassettes/update_group.yml
+++ b/spec/fixtures/truevault_cassettes/update_group.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://REDACTED_ID:@api.truevault.com/v1/groups/REDACTED_ID?
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 Jul 2016 22:55:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '238'
+      Connection:
+      - keep-alive
+      Server:
+      - gunicorn/19.3.0
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"group": {"group_id": "3d88a00b-a87a-417c-ad12-bd01c4a9693a", "id":
+        "REDACTED_ID", "name": "new name", "policy": [], "user_ids": []}, "result":
+        "success", "transaction_id": "REDACTED_ID"}'
+    http_version: 
+  recorded_at: Wed, 20 Jul 2016 22:55:17 GMT
+recorded_with: VCR 2.5.0

--- a/spec/lib/truevault/client_spec.rb
+++ b/spec/lib/truevault/client_spec.rb
@@ -51,7 +51,6 @@ describe TrueVault::Client do
     end
   end
 
-
   describe "create a document" do
     let(:real_document){ TrueVault::Document.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], 'v1') }
     let(:create_document){ real_document.create(ENV["TV_A_VAULT_ID"],{"a" => "document"})}
@@ -117,15 +116,7 @@ describe TrueVault::Client do
     before do
       @real_client = TrueVault::User.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], 'v1')
       VCR.insert_cassette 'create_user'
-      @options = {
-      username: "test_user_3",
-      password: "password",
-      attributes: {
-        "id" => "000",
-        "name" => "John",
-        "type" => "patient"
-        }
-      }
+      @options = attributes_for(:user, attributes: attributes_for(:user_attributes))
     end
 
     after do
@@ -135,6 +126,6 @@ describe TrueVault::Client do
     it "should have a success response" do
       @real_client.create(@options)["result"].must_equal "success"
     end
-    
+
   end
 end

--- a/spec/lib/truevault/group_spec.rb
+++ b/spec/lib/truevault/group_spec.rb
@@ -1,0 +1,200 @@
+require_relative "../../spec_helper"
+
+describe TrueVault::Group do
+  describe "create a group" do
+    let(:real_group){ TrueVault::Group.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+    let(:create_group){ real_group.create(attributes_for(:group)) }
+
+    before do
+      VCR.insert_cassette "create_group"
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    it "must parse the API response from JSON to a Ruby Hash" do
+      create_group.must_be_instance_of Hash
+    end
+
+    it "must have been a successful API request" do
+      create_group["result"].must_equal "success"
+    end
+
+    it "must have a redacted transaction_id" do
+      create_group["transaction_id"].must_equal REDACTED_STRING
+    end
+  end
+
+  describe "list groups" do
+    let(:real_group){ TrueVault::Group.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+    let(:list_groups){ real_group.all }
+
+    before do
+      VCR.insert_cassette "list_groups"
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    it "must have been a successful API request" do
+      list_groups["result"].must_equal "success"
+    end
+
+    it "must return a list of groups" do
+      list_groups["groups"].wont_be_empty
+    end
+  end
+
+  describe "find a group" do
+    let(:real_group){ TrueVault::Group.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+    let(:create_group) do
+      VCR.use_cassette("create_group") { real_group.create(attributes_for(:group)) }
+    end
+
+    let(:find_group){ real_group.find(create_group["group"]["group_id"])}
+
+    before do
+      VCR.insert_cassette "find_group"
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    it "must have been a successful API request" do
+      find_group["result"].must_equal "success"
+    end
+
+    it "must return the group name" do
+      find_group["group"]["name"].wont_be_empty
+    end
+  end
+
+  describe "update a group" do
+    let(:new_name) { "new name" }
+    let(:real_group){ TrueVault::Group.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+
+    let(:create_group) do
+      VCR.use_cassette("create_group") { real_group.create(attributes_for(:group)) }
+    end
+
+    let(:update_group) do
+      group_id = create_group["group"]["group_id"]
+      real_group.update(group_id, {name: new_name})
+    end
+
+    before do
+      VCR.insert_cassette "update_group"
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    it "must have been a successful API request" do
+      update_group["result"].must_equal "success"
+    end
+
+    it "must return the new group name" do
+      update_group["group"]["name"].must_equal new_name
+    end
+  end
+
+  describe "add user to a group" do
+    let(:real_group){ TrueVault::Group.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+    let(:real_user){ TrueVault::User.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+
+    let(:create_group) do
+      VCR.use_cassette("create_group") { real_group.create(attributes_for(:group)) }
+    end
+
+    let(:create_user) do
+      VCR.use_cassette("create_user") do
+        real_user.create(attributes_for(:user, attributes: attributes_for(:user_attributes)))
+      end
+    end
+
+    let(:add_user) do
+      group_id = create_group["group"]["group_id"]
+      user_id = create_user["user"]["user_id"]
+      real_group.add_users(group_id, user_id)
+    end
+
+    before do
+      VCR.insert_cassette "add_user_to_group"
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    it "must have been a successful API request" do
+      add_user["result"].must_equal "success"
+    end
+
+    it "must return the user_ids" do
+      add_user["group"]["user_ids"].wont_be_empty
+    end
+  end
+
+  describe "remove user from a group" do
+    let(:real_group){ TrueVault::Group.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+    let(:real_user){ TrueVault::User.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+
+    let(:create_group) do
+      VCR.use_cassette("create_group") { real_group.create(attributes_for(:group)) }
+    end
+
+    let(:create_user) do
+      VCR.use_cassette("create_user") do
+        real_user.create(attributes_for(:user, attributes: attributes_for(:user_attributes)))
+      end
+    end
+
+    let(:remove_user) do
+      group_id = create_group["group"]["group_id"]
+      user_id = create_user["user"]["user_id"]
+      real_group.remove_users(group_id, user_id)
+    end
+
+    before do
+      VCR.insert_cassette "remove_user_from_group"
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    it "must have been a successful API request" do
+      remove_user["result"].must_equal "success"
+    end
+
+    it "must return the user_ids" do
+      remove_user["group"]["user_ids"].must_be_empty
+    end
+  end
+
+  describe "delete a group" do
+    let(:real_group){ TrueVault::Group.new(ENV["TV_API_KEY"], ENV["TV_ACCOUNT_ID"], "v1") }
+    let(:create_group) do
+      VCR.use_cassette("create_deletable_group") do
+        real_group.create(attributes_for(:deletable_group))
+      end
+    end
+    let(:delete_group){ real_group.delete(create_group["group"]["group_id"]) }
+
+    before do
+      VCR.insert_cassette "delete_group"
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    it "must have been a successful API request" do
+      delete_group["result"].must_equal "success"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,14 @@
 #we need the actual library file
-require_relative '../lib/truevault'
+require_relative "../lib/truevault"
 
 #dependencies
-require 'minitest/autorun'
-require 'webmock/minitest'
-require 'dotenv'
-require 'vcr'
-require 'turn'
+require "factory_girl"
+require "minitest/autorun"
+require "webmock/minitest"
+require "dotenv"
+require "pry"
+require "vcr"
+require "turn"
 
 Dotenv.load
 
@@ -15,16 +17,25 @@ Turn.config do |c|
 	c.natural = true
 end
 
+class Minitest::Spec
+  include FactoryGirl::Syntax::Methods
+end
+
+FactoryGirl.find_definitions
+
 REDACTED_STRING = "REDACTED_ID"
+REDACTED_WHITELIST = ["group_id", "user_id"]
 
 VCR.configure do |c|
-	c.cassette_library_dir = 'spec/fixtures/truevault_cassettes'
+	c.cassette_library_dir = "spec/fixtures/truevault_cassettes"
 	c.hook_into :webmock
 	c.default_cassette_options = { :match_requests_on => [:method], :record => :new_episodes }
 	c.before_record do |interaction|
 		interaction.request.body.gsub!(/(\S{8}-\S{4}-\S{4}-\S{4}-\S{12})/, REDACTED_STRING)
 		interaction.request.uri.gsub!(/(\S{8}-\S{4}-\S{4}-\S{4}-\S{12})/, REDACTED_STRING)
-		interaction.response.body.gsub!(/(\S{8}-\S{4}-\S{4}-\S{4}-\S{12})/, REDACTED_STRING)
+
+		whitelist = REDACTED_WHITELIST.map{|string| "\\\"#{string}\\\": \\\""}.join("|")
+		interaction.response.body.gsub!(/(?<!#{whitelist})(\S{8}-\S{4}-\S{4}-\S{4}-\S{12})/, REDACTED_STRING)
 	end
 
 end

--- a/truevault.gemspec
+++ b/truevault.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'truevault/version'
+require "truevault/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "truevault"
@@ -20,9 +20,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency             "httparty", "~> 0.11"
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake",    "~> 10.1"
+  spec.add_development_dependency "minitest", "~> 4.7"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "rake", "~> 10.1"
+  spec.add_development_dependency "factory_girl", "~> 4.0"
   spec.add_development_dependency "webmock", "1.11"
-  spec.add_development_dependency "vcr",     "~> 2.5"
-  spec.add_development_dependency "turn",    "~> 0.9"
+  spec.add_development_dependency "vcr", "~> 2.5"
+  spec.add_development_dependency "turn", "~> 0.9"
   spec.add_development_dependency "dotenv"
 end


### PR DESCRIPTION
- Wraps TrueVault Groups API endpoints: https://docs.truevault.com/groups
- Follows pattern of existing wrappers
- Endpoints: `Create`, `Read`, `List`, `Update`, `Delete`
- Additionally, defined `add_users` and `remove_users` for convenience, which use the `Update` endpoint

Something that bothers me about the tests.. the way VCR cassettes are used here kind of defeats the purpose of testing.  After the first run, the responses are cached regardless of what is sent on subsequent test runs.. meaning one could break the API wrapper and tests would still pass.
